### PR TITLE
Fetch runs tweaks

### DIFF
--- a/fetch_runs/fetch_runs.py
+++ b/fetch_runs/fetch_runs.py
@@ -143,6 +143,9 @@ if __name__ == "__main__":
 
         if run.contact.uuid in test_contacts:
             run_dict["test_run"] = True
+        else:
+            assert len(contact_urns) == 1, \
+                f"A non-test contact has multiple URNs (Rapid Pro Contact UUID: {run.contact.uuid})"
 
         if mode == "all":
             run_dict["created_on"] = run.created_on.isoformat()

--- a/fetch_runs/fetch_runs.py
+++ b/fetch_runs/fetch_runs.py
@@ -126,8 +126,10 @@ if __name__ == "__main__":
             print("Warning: Ignoring contact with no urn. URNs: {}, UUID: {}".format(contact_urns, run.contact.uuid))
             continue
         
-        # assert len(contact_urns) == 1, "Contact has multiple URNs" TODO: Re-enable once AVF test runs are ignored.
-        run_dict = {"avf_phone_id": phone_uuids.add_phone(contact_urns[0])}
+        run_dict = {
+            "avf_phone_id": phone_uuids.add_phone(contact_urns[0]),
+            "run_id": run.id
+        }
 
         for category, response in run.values.items():
             run_dict[category.title() + " (Category) - " + run.flow.name] = response.category

--- a/fetch_runs/fetch_runs.py
+++ b/fetch_runs/fetch_runs.py
@@ -82,7 +82,7 @@ if __name__ == "__main__":
 
         if len(matching_flows) == 0:
             raise KeyError("Requested flow not found on RapidPro (Available flows: {})".format(
-                           ",".join(list(map(lambda f: f.name, flows)))))
+                           ", ".join(list(map(lambda f: f.name, flows)))))
         if len(matching_flows) > 1:
             raise KeyError("Non-unique flow name")
 

--- a/fetch_runs/fetch_runs.py
+++ b/fetch_runs/fetch_runs.py
@@ -117,7 +117,8 @@ if __name__ == "__main__":
             # Sometimes contact uuids which appear in `runs` do not appear in `contact_runs`.
             # I have only observed this happen for contacts which were created very recently.
             # This test skips the run in this case; it should be included next time this script is executed.
-            print("Warning: Run found with uuid '{}', but this id is not present in contacts".format(run.contact.uuid))
+            print(f"Warning: Run found with Rapid Pro Contact UUID '{run.contact.uuid}', "
+                  f"but this id is not present in the downloaded contacts")
             continue
 
         contact_urns = contact_runs[run.contact.uuid].urns

--- a/fetch_runs/fetch_runs.py
+++ b/fetch_runs/fetch_runs.py
@@ -123,7 +123,8 @@ if __name__ == "__main__":
         contact_urns = contact_runs[run.contact.uuid].urns
         
         if len(contact_urns) == 0:
-            print("Warning: Ignoring contact with no urn. URNs: {}, UUID: {}".format(contact_urns, run.contact.uuid))
+            print(f"Warning: Ignoring contact with no urn. URNs: {contact_urns}, "
+                  f"Rapid Pro Contact UUID: {run.contact.uuid}")
             continue
         
         run_dict = {

--- a/fetch_runs/fetch_runs.py
+++ b/fetch_runs/fetch_runs.py
@@ -123,8 +123,8 @@ if __name__ == "__main__":
         contact_urns = contact_runs[run.contact.uuid].urns
         
         if len(contact_urns) == 0:
-            print(f"Warning: Ignoring contact with no urn. URNs: {contact_urns}, "
-                  f"Rapid Pro Contact UUID: {run.contact.uuid}")
+            print(f"Warning: Ignoring contact with no urn. URNs: {contact_urns} "
+                  f"(Rapid Pro Contact UUID: {run.contact.uuid})")
             continue
         
         run_dict = {

--- a/fetch_runs/fetch_runs.py
+++ b/fetch_runs/fetch_runs.py
@@ -130,7 +130,7 @@ if __name__ == "__main__":
         
         run_dict = {
             "avf_phone_id": phone_uuids.add_phone(contact_urns[0]),
-            "run_id": run.id
+            f"run_id - {run.flow.name}": run.id
         }
 
         for category, response in run.values.items():


### PR DESCRIPTION
This PR makes the following small changes:
- Includes the 'run_id' as a top-level property of each run. Previously, Run IDs were only available in the response fields, but this doesn't allow us to index runs which don't have any responses yet.
- Addresses a long-standing TODO about checking for production contacts having multiple URNs.
- When complaining about uuids, makes it clear that this is the Rapid Pro Contact UUID that is problematic (as opposed to some other UUID).
- Formatting improvements.

Included together in one PR because they're so tiny, but can split into multiple if need be.