### PR TITLE
Get all flow ids

### DIFF
--- a/rapid_pro_tools/rapid_pro_client.py
+++ b/rapid_pro_tools/rapid_pro_client.py
@@ -58,6 +58,12 @@ class RapidProClient(object):
         return [self.get_flow_id(name) for name in flow_names]
 
     def get_all_flow_ids(self):
+        """
+        Gets all the flow ids currently available on the Rapid Pro instance.
+        
+        :return: Ids of all flows on Rapid Pro instance.
+        :rtype: list of str
+        """
         return [f.uuid for f in self.rapid_pro.get_flows().all(retry_on_rate_exceed=True)]
 
     def get_flow_definitions_for_flow_ids(self, flow_ids):

--- a/rapid_pro_tools/rapid_pro_client.py
+++ b/rapid_pro_tools/rapid_pro_client.py
@@ -58,7 +58,7 @@ class RapidProClient(object):
         return [self.get_flow_id(name) for name in flow_names]
 
     def get_all_flow_ids(self):
-        return self.rapid_pro.get_flows()
+        return [f.uuid for f in self.rapid_pro.get_flows().all(retry_on_rate_exceed=True)]
 
     def get_flow_definitions_for_flow_ids(self, flow_ids):
         """

--- a/rapid_pro_tools/rapid_pro_client.py
+++ b/rapid_pro_tools/rapid_pro_client.py
@@ -57,6 +57,9 @@ class RapidProClient(object):
         """
         return [self.get_flow_id(name) for name in flow_names]
 
+    def get_all_flow_ids(self):
+        return self.rapid_pro.get_flows()
+
     def get_flow_definitions_for_flow_ids(self, flow_ids):
         """
         Gets the definitions for the flows with the requested ids from Rapid Pro.


### PR DESCRIPTION
This is needed in order to be able to request that all flows are fetched when downloading the latest flow definitions.