### PR TITLE
Automatically fetch runs from archives

### DIFF
--- a/rapid_pro_tools/rapid_pro_client.py
+++ b/rapid_pro_tools/rapid_pro_client.py
@@ -64,7 +64,8 @@ class RapidProClient(object):
         :rtype: list of temba_client.v2.Message | list of temba_client.v2.Run
         """
         # Download the archive, which is in a gzipped JSONL format, and decompress.
-        log.info(f"Downloading {archive_metadata.record_count} records from archive {archive_metadata.download_url}...")
+        log.info(f"Downloading {archive_metadata.record_count} records from {archive_metadata.period} archive "
+                 f"{archive_metadata.start_date} ({archive_metadata.download_url})...")
         archive_response = urllib.request.urlopen(archive_metadata.download_url)
         raw_file = BytesIO(archive_response.read())
         decompressed_file = gzip.GzipFile(fileobj=raw_file)

--- a/rapid_pro_tools/rapid_pro_client.py
+++ b/rapid_pro_tools/rapid_pro_client.py
@@ -316,9 +316,12 @@ class RapidProClient(object):
         # Check that we only see each run once. This shouldn't be possible, due to
         # https://github.com/nyaruka/rp-archiver/blob/7d3430b5260fa92abb62d828fc526af8e9d9d50a/archiver.go#L624,
         # but this check exists to be safe.
-        assert len(raw_runs) == len({run.id for run in raw_runs}), "Duplicate run found in the downloaded data. " \
-                                                                   "This could be because a run with this id exists " \
-                                                                   "in both the archives and live database."
+        seen_run_ids = set()
+        for run in raw_runs:
+            assert run.id not in seen_run_ids, f"Duplicate run {run.id} found in the downloaded data. This could be " \
+                                               f"because a run with this id exists in both the archives and the live " \
+                                               f"database."
+            seen_run_ids.add(run.id)
 
         if raw_export_log_file is not None:
             log.info(f"Logging {len(raw_runs)} fetched runs...")

--- a/rapid_pro_tools/rapid_pro_client.py
+++ b/rapid_pro_tools/rapid_pro_client.py
@@ -224,19 +224,37 @@ class RapidProClient(object):
 
     def _get_archived_runs_for_flow_id(self, flow_id, last_modified_after_inclusive=None,
                                        last_modified_before_exclusive=None):
+        """
+        Gets the raw runs for the given flow_id from Rapid Pro's archives.
+        
+        Uses the last_modified dates to determine which archives to download.
+
+        :param flow_id: Id of the flow to download the runs of.
+        :type flow_id: str
+        :param last_modified_after_inclusive: Start of the date-range to download runs from.
+                                              If set, only downloads runs last modified since that date,
+                                              otherwise downloads from the beginning of time.
+        :type last_modified_after_inclusive: datetime.datetime | None
+        :param last_modified_before_exclusive: End of the date-range to download runs from.
+                                               If set, only downloads runs last modified before that date,
+                                               otherwise downloads until the end of time.
+        :return: Raw runs downloaded from Rapid Pro's archives.
+        :rtype: list of temba_client.v2.types.Run
+        """
         runs = []
         for archive_metadata in self.list_archives("run"):
-            archive_start_range = archive_metadata.start_date
+            # Determine the start and end dates for this archive
+            archive_start_date = archive_metadata.start_date
             if archive_metadata.period == "daily":
-                archive_end_range = archive_start_range + relativedelta(days=1, microseconds=-1)
+                archive_end_date = archive_start_date + relativedelta(days=1, microseconds=-1)
             else:
                 assert archive_metadata.period == "monthly"
-                archive_end_range = archive_start_range + relativedelta(months=1, microseconds=-1)
+                archive_end_date = archive_start_date + relativedelta(months=1, microseconds=-1)
 
-            if (last_modified_after_inclusive is not None and archive_end_range < last_modified_after_inclusive) or \
-                    (last_modified_before_exclusive is not None and archive_start_range >= last_modified_before_exclusive):
-                log.debug(f"Skipping archive with start date {archive_metadata.start_date} and period "
-                          f"'{archive_metadata.period}' (derived end date for this archive was {archive_end_range})")
+            if (last_modified_after_inclusive is not None and archive_end_date < last_modified_after_inclusive) or \
+                    (last_modified_before_exclusive is not None and archive_start_date >= last_modified_before_exclusive):
+                log.debug(f"Skipping {archive_metadata.period} archive with date range {archive_start_date} - "
+                          f"{archive_end_date}")
                 continue
 
             for run in self.get_archive(archive_metadata):
@@ -256,7 +274,7 @@ class RapidProClient(object):
     def get_raw_runs_for_flow_id(self, flow_id, last_modified_after_inclusive=None, last_modified_before_exclusive=None,
                                  raw_export_log_file=None):
         """
-        Gets the raw runs for the given flow_id from RapidPro.
+        Gets the raw runs for the given flow_id from Rapid Pro's live database and, if needed, from its archives.
 
         :param flow_id: Id of the flow to download the runs of.
         :type flow_id: str


### PR DESCRIPTION
Automatically fetches runs from archives when necessary. Works as a drop-in replacement for previous versions of Rapid Pro Tools in the pipelines.

Main caveat is that it does some unnecessary work, e.g.:
 - Will fetch all archives once *for each flow*, so expensive when starting up.
 - Fetches archives known to be empty.
 - Pipelines request all runs since the modification date of the most recent run in that flow when running incrementally. This means for the oldest runs, time will be wasted searching in more recent archives, because the most recent update will fall in the archive period, which will hurt the performance of incremental fetching.

But better to get something that works than pre-optimise.

Takes <1 hour to fetch all data for WorldBank (7 flows from 2 different TextIt instances).