### PR TITLE
Log production fetches

### DIFF
--- a/rapid_pro_tools/rapid_pro_client.py
+++ b/rapid_pro_tools/rapid_pro_client.py
@@ -223,6 +223,7 @@ class RapidProClient(object):
                 created_before_exclusive=created_before_exclusive
             )
 
+        log.info(f"Fetching messages from production Rapid Pro instance...")
         live_messages = self.rapid_pro.get_messages(after=created_after_inclusive, before=created_before_inclusive)\
             .all(retry_on_rate_exceed=True)
 
@@ -373,6 +374,7 @@ class RapidProClient(object):
                 last_modified_before_exclusive=last_modified_before_exclusive
             )
 
+        log.info(f"Fetching runs from production Rapid Pro instance...")
         live_runs = self.rapid_pro.get_runs(
             flow=flow_id, after=last_modified_after_inclusive, before=last_modified_before_inclusive
         ).all(retry_on_rate_exceed=True)


### PR DESCRIPTION
Review #66 first.

Current behaviour when fetching is to log all the archives being examined, then mysteriously freeze for a few minutes while pulling data from the production database. Logging that we're about to go to production explains that otherwise mysterious freeze.