### PR TITLE
Make the flow_definitions_upload_url_prefix optional

### DIFF
--- a/fetch_flow_definitions/fetch_flow_definitions.py
+++ b/fetch_flow_definitions/fetch_flow_definitions.py
@@ -37,6 +37,11 @@ if __name__ == "__main__":
     log.info(f"Loaded the details for {len(active_projects)} active projects")
 
     for project in active_projects:
+        if project.flow_definitions_upload_url_prefix is None:
+            log.info(f"Not archiving flow definitions for project {project.project_name} because its "
+                     f"'flow_definitions_upload_url_prefix' is unspecified.")
+            continue
+
         log.info(f"Archiving the latest flow definitions for project {project.project_name}...")
 
         log.info("Downloading the Rapid Pro token file and initialising the Rapid Pro client...")

--- a/fetch_flow_definitions/src/data_models/active_project.py
+++ b/fetch_flow_definitions/src/data_models/active_project.py
@@ -10,6 +10,6 @@ class ActiveProject(object):
         project_name = source["project_name"]
         rapid_pro_domain = source["rapid_pro_domain"]
         rapid_pro_token_url = source["rapid_pro_token_url"]
-        flow_definitions_upload_url_prefix = source["flow_definitions_upload_url_prefix"]
+        flow_definitions_upload_url_prefix = source.get("flow_definitions_upload_url_prefix")
 
         return cls(project_name, rapid_pro_domain, rapid_pro_token_url, flow_definitions_upload_url_prefix)


### PR DESCRIPTION
If this isn't present in the project's active_projects definition, fetching flow definitions for that will be skipped, and an info message printed.