### PR TITLE
Add multi-send

### DIFF
--- a/rapid_pro_tools/rapid_pro_client.py
+++ b/rapid_pro_tools/rapid_pro_client.py
@@ -273,7 +273,7 @@ class RapidProClient(object):
         
         log.info("Sending a message to an individual...")
         log.debug(f"Sending to '{target_urn}' the message '{message}'...")
-        response: Broadcast = self.rapid_pro.create_broadcast(message, urns=[target_urn])
+        response = self.rapid_pro.create_broadcast(message, urns=[target_urn])
         log.info(f"Message send request created with broadcast id {response.id}")
         return response.id
 
@@ -295,7 +295,7 @@ class RapidProClient(object):
         log.info(f"Sending a message to {len(urns)} URNs...")
         log.debug(f"Sending to {urns}...")
         batch = []
-        ids = []
+        broadcast_ids = []
         interrupted = 0
         sent = 0
 
@@ -307,22 +307,20 @@ class RapidProClient(object):
                     interrupted += len(batch)
                     log.info(f"Interrupted {interrupted} / {len(urns)} URNs")
 
-                response: Broadcast = self.rapid_pro.create_broadcast(message, urns=batch)
-                ids.append(response.id)
+                response = self.rapid_pro.create_broadcast(message, urns=batch)
+                broadcast_ids.append(response.id)
                 sent += len(batch)
                 batch = []
+                log.info(f"Sent {sent} / {len(urns)} URNs")
         if len(batch) > 0:
             if interrupt:
                 self.rapid_pro.bulk_interrupt_contacts(batch)
                 interrupted += len(batch)
             response: Broadcast = self.rapid_pro.create_broadcast(message, urns=batch)
             sent += len(batch)
-
-            ids.append(response.id)
-
-
-        log.info(f"Interrupted {interrupted} / {len(urns)} URNs")
-        log.info(f"Sent {sent} / {len(urns)} URNs")
+            broadcast_ids.append(response.id)
+            log.info(f"Interrupted {interrupted} / {len(urns)} URNs")
+            log.info(f"Sent {sent} / {len(urns)} URNs")
 
         log.info(f"Message send request created with broadcast ids {ids}")
         return ids

--- a/rapid_pro_tools/rapid_pro_client.py
+++ b/rapid_pro_tools/rapid_pro_client.py
@@ -277,6 +277,55 @@ class RapidProClient(object):
         log.info(f"Message send request created with broadcast id {response.id}")
         return response.id
 
+    def send_message_to_urns(self, message, target_urns, interrupt=False):
+        """
+        Sends a message to URNs.
+
+        :param message: Text of the message to send.
+        :type message: str
+        :param target_urn: URNs to send the message to.
+        :type target_urn: str
+        :param interrupt: Whether to interrupt the target_urn from flows before sending the message.
+        :type interrupt: bool
+        :return: Ids of the Rapid Pro broadcasts created for this send request.
+                 These ids may be used to check on the status of the broadcast by making further requests to Rapid Pro.
+        :rtype: list of int
+        """
+        log.info(f"Sending a message to {len(urns)} URNs...")
+        log.debug(f"Sending to {urns}...")
+        batch = []
+        ids = []
+        interrupted = 0
+        sent = 0
+
+        for urn in urns:
+            batch.append(urn)
+            if len(batch) >= 100:  # limit of 100 imposed by Rapid Pro's API
+                if interrupt:
+                    self.rapid_pro.bulk_interrupt_contacts(batch)
+                    interrupted += len(batch)
+                    log.info(f"Interrupted {interrupted} / {len(urns)} URNs")
+
+                response: Broadcast = self.rapid_pro.create_broadcast(message, urns=batch)
+                ids.append(response.id)
+                sent += len(batch)
+                batch = []
+        if len(batch) > 0:
+            if interrupt:
+                self.rapid_pro.bulk_interrupt_contacts(batch)
+                interrupted += len(batch)
+            response: Broadcast = self.rapid_pro.create_broadcast(message, urns=batch)
+            sent += len(batch)
+
+            ids.append(response.id)
+
+
+        log.info(f"Interrupted {interrupted} / {len(urns)} URNs")
+        log.info(f"Sent {sent} / {len(urns)} URNs")
+
+        log.info(f"Message send request created with broadcasts ids {ids}")
+        return ids
+
     def get_broadcast_for_broadcast_id(self, broadcast_id):
         """
         Gets the broadcast with the requested id from Rapid Pro.

--- a/rapid_pro_tools/rapid_pro_client.py
+++ b/rapid_pro_tools/rapid_pro_client.py
@@ -285,7 +285,7 @@ class RapidProClient(object):
         :type message: str
         :param target_urn: URNs to send the message to.
         :type target_urn: str
-        :param interrupt: Whether to interrupt the target_urn from flows before sending the message.
+        :param interrupt: Whether to interrupt the target_urns from flows before sending the message.
         :type interrupt: bool
         :return: Ids of the Rapid Pro broadcasts created for this send request.
                  These ids may be used to check on the status of the broadcast by making further requests to Rapid Pro.

--- a/rapid_pro_tools/rapid_pro_client.py
+++ b/rapid_pro_tools/rapid_pro_client.py
@@ -324,7 +324,7 @@ class RapidProClient(object):
         log.info(f"Interrupted {interrupted} / {len(urns)} URNs")
         log.info(f"Sent {sent} / {len(urns)} URNs")
 
-        log.info(f"Message send request created with broadcasts ids {ids}")
+        log.info(f"Message send request created with broadcast ids {ids}")
         return ids
 
     def get_broadcast_for_broadcast_id(self, broadcast_id):

--- a/rapid_pro_tools/rapid_pro_client.py
+++ b/rapid_pro_tools/rapid_pro_client.py
@@ -289,6 +289,7 @@ class RapidProClient(object):
         :type interrupt: bool
         :return: Ids of the Rapid Pro broadcasts created for this send request.
                  These ids may be used to check on the status of the broadcast by making further requests to Rapid Pro.
+                 e.g. using get_broadcast_for_broadcast_id.
         :rtype: list of int
         """
         log.info(f"Sending a message to {len(urns)} URNs...")


### PR DESCRIPTION
@as2388 I'd like to add something like this to the code. The testing is going to be pretty laborious - so if you could take a look at the direction to see if you want something different before I start testing that would be great.

I've written it on the basis that we might want to deprecate and remove the 'send to single' API which will make it consistent with the interrupt API we surface.

If you're ok with this, I'll send you a proper PR after I'm done with testing and any changes needed