### PR TITLE
Add RapidProClient.instance_name()

### DIFF
--- a/rapid_pro_tools/rapid_pro_client.py
+++ b/rapid_pro_tools/rapid_pro_client.py
@@ -30,6 +30,13 @@ class RapidProClient(object):
         :type token: str
         """
         self.rapid_pro = TembaClient(server, token)
+
+    def instance_name(self):
+        """
+        :return: The name of this instance.
+        :rtype: str
+        """
+        return self.rapid_pro.get_org(retry_on_rate_exceed=True).name
         
     def list_archives(self, archive_type=None):
         """

--- a/rapid_pro_tools/rapid_pro_client.py
+++ b/rapid_pro_tools/rapid_pro_client.py
@@ -31,7 +31,7 @@ class RapidProClient(object):
         """
         self.rapid_pro = TembaClient(server, token)
 
-    def instance_name(self):
+    def get_instance_name(self):
         """
         :return: The name of this instance.
         :rtype: str


### PR DESCRIPTION
I'd like to add this so we can identify instances more easily in logs when synchronising contacts.