### PR TITLE
Add urn_type field to traced data

### DIFF
--- a/rapid_pro_tools/rapid_pro_client.py
+++ b/rapid_pro_tools/rapid_pro_client.py
@@ -897,6 +897,7 @@ class RapidProClient(object):
             contact_urns = contacts_lut[run.contact.uuid].urns
             run_dict = {
                 "avf_phone_id": phone_to_uuid_lut[PhoneCleaner.normalise_phone(contact_urns[0])],
+                "urn_type": contact_urns[0].split(":")[0],
                 f"run_id - {run.flow.name}": run.id
             }
 


### PR DESCRIPTION
`convert_runs_to_traced_data()` uses PhoneCleaner.normalise_phone in all cases, which strips the urn type. This seemed like a good idea at the time, but causes problems when working with telegram as those are being processed as phone numbers, causing complications in pipelines. As a workaround, this adds a urn_type, so the pipelines can decide how to interpret numbers based on whether they are telephone or telegram ids.

(In the long-term, including urns in the uuid tables might be a better way of handling this).